### PR TITLE
Fix DbOpts::DbOptions#apply and tests

### DIFF
--- a/lib/sequel/extensions/db_opts.rb
+++ b/lib/sequel/extensions/db_opts.rb
@@ -19,20 +19,7 @@ module Sequel
 
       def apply(c)
         sql_statements.each do |stmt|
-          if db.respond_to?(:log_connection_execute)
-            db.send(:log_connection_execute, c, stmt)
-          elsif c.respond_to?(:log_connection_execute)
-            c.send(:log_connection_execute, stmt)
-          elsif c.respond_to?(:execute)
-            cursor = c.send(:execute, stmt)
-            if cursor && cursor.respond_to?(:close)
-              cursor.close
-            end
-          elsif db.respond_to?(:execute)
-            db.send(:execute, stmt)
-          else
-            raise "Failed to run SET queries"
-          end
+          db.send(:log_connection_execute, c, stmt)
         end
       end
 

--- a/test/lib/sequel/extensions/test_db_opts.rb
+++ b/test/lib/sequel/extensions/test_db_opts.rb
@@ -4,69 +4,37 @@ require 'sequel/extensions/db_opts'
 
 class TestDbOpts < Minitest::Test
   def with_fake_database_type_and_options(db_type, opts = {})
-    db = Minitest::Mock.new
-    db.expect :extension, nil, [:settable]
-    db.expect :database_type, db_type
-    db.expect :opts, opts
+    db = Sequel.mock
+    db.define_singleton_method(:database_type){db_type}
+    db.define_singleton_method(:opts){opts}
+    db.extension :db_opts
     yield db
-    db.verify
   end
 
-  def with_conn
-    conn = Minitest::Mock.new
-    yield conn
-    conn.verify
+  def sql_for(db_type, options)
+    with_fake_database_type_and_options(db_type, options) do |db|
+      db.synchronize do |conn|
+        db.db_opts.apply(conn)
+        return db.sqls
+      end
+    end
   end
 
   def test_should_detect_options_for_appropriate_db
-    with_fake_database_type_and_options(:postgres, postgres_db_opt_flim: :flam) do |db|
-      with_conn do |conn|
-        returns = ["SET flim=flam"]
-        db.expect :set_sql, returns, [flim: :flam]
-        conn.expect :execute, nil, returns
-        db_opts = Sequel::DbOpts::DbOptions.new(db)
-        db_opts.apply(conn)
-      end
-    end
+    assert_equal(sql_for(:postgres, postgres_db_opt_flim: :flam), ["SET flim=flam"])
   end
 
   def test_should_ignore_options_for_inappropriate_db
-    with_fake_database_type_and_options(:postgres, postgres_db_opt_flim: :flam, other_db_opt_foo: :bar) do |db|
-      with_conn do |conn|
-        returns = ["SET flim=flam"]
-        db.expect :set_sql, returns, [flim: :flam]
-        conn.expect :execute, nil, returns
-        db_opts = Sequel::DbOpts::DbOptions.new(db)
-        db_opts.apply(conn)
-      end
-    end
+    assert_equal(sql_for(:postgres, postgres_db_opt_flim: :flam, other_db_opt_foo: :bar), ["SET flim=flam"])
   end
 
   def test_should_ignore_non_db_opts
-    with_fake_database_type_and_options(:postgres, postgres_flim: :flam) do |db|
-      with_conn do |conn|
-        returns = []
-        db.expect :set_sql, returns, [{}]
-        db_opts = Sequel::DbOpts::DbOptions.new(db)
-        db_opts.apply(conn)
-      end
-    end
+    assert_equal(sql_for(:postgres, postgres_flim: :flam), [])
   end
 
   def test_should_properly_quote_awkward_values
-    with_fake_database_type_and_options(:postgres, postgres_db_opt_str: "hello there", postgres_db_opt_hyphen: "i-like-hyphens-though-they-are-dumb") do |db|
-      with_conn do |conn|
-        db.expect :literal, "hello there", ["hello there"]
-        db.expect :literal, "i-like-hyphens-though-they-are-dumb", ["i-like-hyphens-though-they-are-dumb"]
-        returns = ["SET str='hello there'", "SET hyphens='i-like-hyphens-though-they-are-dumb'"]
-        db.expect :set_sql, returns, [{str: "hello there", hyphen: "i-like-hyphens-though-they-are-dumb"}]
-        returns.each do |stmt|
-          conn.expect :execute, nil, [stmt]
-        end
-        db_opts = Sequel::DbOpts::DbOptions.new(db)
-        db_opts.apply(conn)
-      end
-    end
+    assert_equal(sql_for(:postgres, postgres_db_opt_str: "hello there", postgres_db_opt_hyphen: "i-like-hyphens-though-they-are-dumb"),
+      ["SET str='hello there'", "SET hyphen='i-like-hyphens-though-they-are-dumb'"])
   end
 end
 


### PR DESCRIPTION
Sequel::Database#log_connection_execute should always be defined
correctly, or it is a bug in the database adapter.  It's a private
method, so respond_to? will return false unless you pass true as
the second argument.  Since it should always be defined, just
calling it with send seems best.

This broke the tests, which use an very brittle mocking design.
Switch the tests to use Sequel's mock database adapter, then nothing
needs to be mocked in the tests themselves, the tests are far more
robust, and also much easier to understand.