### PR TITLE
fix: make GitHub config writable in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -85,6 +85,8 @@ WORKDIR /workspace
 # Switch to non-root user before gem installation
 USER $USERNAME
 
+RUN gem install overcommit:0.67.1
+
 # Set up ZSH with powerline10k theme (from Claude Code setup)
 RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.1.5/zsh-in-docker.sh)" -- \
   -t https://github.com/romkatv/powerlevel10k \

--- a/.devcontainer/copy-claude-credentials.sh
+++ b/.devcontainer/copy-claude-credentials.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "Copying Claude credentials from host..."
+echo "Copying Claude credentials and GitHub config from host..."
 
 # Create .claude directory if it doesn't exist
 mkdir -p ~/.claude
@@ -19,7 +19,14 @@ if [ -f "/tmp/host-claude.json" ]; then
     cp /tmp/host-claude.json ~/.claude.json
 fi
 
+# Create writable GitHub config directory and copy from readonly mount
+mkdir -p ~/.config/gh
+if [ -d "/tmp/host-gh" ]; then
+    cp -r /tmp/host-gh/* ~/.config/gh/ 2>/dev/null || true
+fi
+
 # Set proper permissions
 chmod 700 ~/.claude
+chmod 700 ~/.config/gh 2>/dev/null || true
 
-echo "Done copying Claude credentials"
+echo "Done copying Claude credentials and GitHub config"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
     "type=bind,source=${localEnv:HOME}/.claude.json,target=/tmp/host-claude.json,readonly",
     "type=bind,source=${localEnv:HOME}/.gitconfig,target=/home/rubydev/.gitconfig,readonly",
     "type=bind,source=${localEnv:HOME}/.ssh,target=/home/rubydev/.ssh,readonly",
-    "type=bind,source=${localEnv:HOME}/.config/gh,target=/home/rubydev/.config/gh,readonly",
+    "type=bind,source=${localEnv:HOME}/.config/gh,target=/tmp/host-gh,readonly",
     "source=ruby-command-history,target=/commandhistory,type=volume"
   ],
   "postCreateCommand": "/usr/local/bin/setup-credentials.sh && /usr/local/bin/copy-claude-credentials.sh",


### PR DESCRIPTION
## Summary
- Makes GitHub config directory writable in devcontainer by mounting to temp location first
- Updates credential copying script to handle GitHub config properly
- Installs overcommit globally to prevent pre-commit hook issues

## Test plan
- [ ] Build devcontainer successfully
- [ ] Verify GitHub CLI works with proper authentication
- [ ] Confirm overcommit hooks run without errors

🤖 Generated with [Claude Code](https://claude.ai/code)