### PR TITLE
feat: update sequel dependency to version 5.93.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,13 +13,14 @@ PATH
     sequelizer (0.1.5)
       dotenv (~> 2.1)
       hashie (~> 3.2)
-      sequel (~> 5.0)
+      sequel (~> 5.93.0)
       thor (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    bigdecimal (3.2.2)
     childprocess (5.1.0)
       logger (~> 1.5)
     coderay (1.1.3)
@@ -97,7 +98,8 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
-    sequel (5.29.0)
+    sequel (5.93.0)
+      bigdecimal
     shellany (0.0.1)
     simplecov (0.22.0)
       docile (~> 1.1)

--- a/sequelizer.gemspec
+++ b/sequelizer.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_dependency 'dotenv', '~> 2.1'
   spec.add_dependency 'hashie', '~> 3.2'
-  spec.add_dependency 'sequel', '~> 5.0'
+  spec.add_dependency 'sequel', '~> 5.93.0'
   spec.add_dependency 'thor', '~> 1.0'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
## Summary
- Updated Sequel gem dependency from `~> 5.0` to `~> 5.93.0` in sequelizer.gemspec
- Updated Gemfile.lock with new version and associated dependencies (bigdecimal)
- Verified compatibility by running full test suite - all 85 tests pass

## Test plan
- [x] All existing tests pass (85 runs, 177 assertions, 0 failures, 0 errors)
- [x] Bundle install completed successfully with new dependency version
- [x] Code linting shows only pre-existing style issues, no new errors

🤖 Generated with [Claude Code](https://claude.ai/code)